### PR TITLE
Simplify PageSpeed Insights Widget + README improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ import PageSpeedInsightsScore from '../components/widgets/pagespeed-insights/sco
 * `url`: URL to fetch and analyze
 * `strategy`: Analysis strategy (Default: `desktop`)
   * Acceptable values: `desktop` | `mobile`
-* `filterThirdPartyResources`: Indicates if third party resources should be filtered out (Default: `true`)
+* `filterThirdPartyResources`: Indicates if third party resources should be filtered out (Default: `false`)
 
 ### [PageSpeed Insights Stats](./components/widgets/pagespeed-insights/stats.js)
 
@@ -223,7 +223,7 @@ import PageSpeedInsightsStats from '../components/widgets/pagespeed-insights/sta
 * `url`: URL to fetch and analyze
 * `strategy`: Analysis strategy (Default: `desktop`)
   * Acceptable values: `desktop` | `mobile`
-* `filterThirdPartyResources`: Indicates if third party resources should be filtered out (Default: `true`)
+* `filterThirdPartyResources`: Indicates if third party resources should be filtered out (Default: `false`)
 
 ### [SonarQube](./components/widgets/sonarqube/index.js)
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ import DateTime from '../components/widgets/datetime'
 import Jenkins from '../components/widgets/jenkins'
 
 <Jenkins
-  url="https://crossorigin.me/http://ci.jenkins-ci.org"
+  url="http://ci.jenkins-ci.org"
   jobs={[
     { label: 'jenkins master', path: 'Core/job/jenkins/job/master/' },
     { label: 'jenkins stable', path: 'Core/job/jenkins/job/stable-2.7/'},

--- a/README.md
+++ b/README.md
@@ -202,7 +202,6 @@ import PageSpeedInsightsScore from '../components/widgets/pagespeed-insights/sco
 * `title`: Widget title (Default: `PageSpeed Score`)
 * `interval`: Refresh interval in milliseconds (Default: `43200000`)
 * `url`: URL to fetch and analyze
-* `locale`: Locale used to localize formatted results (Default: `de_DE`)
 * `strategy`: Analysis strategy (Default: `desktop`)
   * Acceptable values: `desktop` | `mobile`
 * `filterThirdPartyResources`: Indicates if third party resources should be filtered out (Default: `true`)
@@ -222,7 +221,6 @@ import PageSpeedInsightsStats from '../components/widgets/pagespeed-insights/sta
 * `title`: Widget title (Default: `PageSpeed Stats`)
 * `interval`: Refresh interval in milliseconds (Default: `43200000`)
 * `url`: URL to fetch and analyze
-* `locale`: Locale used to localize formatted results (Default: `de_DE`)
 * `strategy`: Analysis strategy (Default: `desktop`)
   * Acceptable values: `desktop` | `mobile`
 * `filterThirdPartyResources`: Indicates if third party resources should be filtered out (Default: `true`)

--- a/components/widgets/pagespeed-insights/score.js
+++ b/components/widgets/pagespeed-insights/score.js
@@ -5,7 +5,7 @@ import Widget from '../../widget'
 
 export default class PageSpeedInsightsScore extends Component {
   static defaultProps = {
-    filterThirdPartyResources: true,
+    filterThirdPartyResources: false,
     interval: 1000 * 60 * 60 * 12,
     strategy: 'desktop',
     title: 'PageSpeed Score'

--- a/components/widgets/pagespeed-insights/score.js
+++ b/components/widgets/pagespeed-insights/score.js
@@ -7,7 +7,6 @@ export default class PageSpeedInsightsScore extends Component {
   static defaultProps = {
     filterThirdPartyResources: true,
     interval: 1000 * 60 * 60 * 12,
-    locale: 'de_DE',
     strategy: 'desktop',
     title: 'PageSpeed Score'
   }
@@ -27,12 +26,11 @@ export default class PageSpeedInsightsScore extends Component {
   }
 
   async fetchInformation () {
-    const { url, filterThirdPartyResources, locale, strategy } = this.props
+    const { url, filterThirdPartyResources, strategy } = this.props
 
     const searchParams = [
       `url=${url}`,
       `filter_third_party_resources=${filterThirdPartyResources}`,
-      `locale=${locale}`,
       `strategy=${strategy}`
     ].join('&')
 

--- a/components/widgets/pagespeed-insights/stats.js
+++ b/components/widgets/pagespeed-insights/stats.js
@@ -5,7 +5,7 @@ import Widget from '../../widget'
 
 export default class PageSpeedInsightsStats extends Component {
   static defaultProps = {
-    filterThirdPartyResources: true,
+    filterThirdPartyResources: false,
     interval: 1000 * 60 * 60 * 12,
     strategy: 'desktop',
     title: 'PageSpeed Stats'

--- a/components/widgets/pagespeed-insights/stats.js
+++ b/components/widgets/pagespeed-insights/stats.js
@@ -7,7 +7,6 @@ export default class PageSpeedInsightsStats extends Component {
   static defaultProps = {
     filterThirdPartyResources: true,
     interval: 1000 * 60 * 60 * 12,
-    locale: 'de_DE',
     strategy: 'desktop',
     title: 'PageSpeed Stats'
   }
@@ -31,12 +30,11 @@ export default class PageSpeedInsightsStats extends Component {
   }
 
   async fetchInformation () {
-    const { url, filterThirdPartyResources, locale, strategy } = this.props
+    const { url, filterThirdPartyResources, strategy } = this.props
 
     const searchParams = [
       `url=${url}`,
       `filter_third_party_resources=${filterThirdPartyResources}`,
-      `locale=${locale}`,
       `strategy=${strategy}`
     ].join('&')
 

--- a/components/widgets/pagespeed-insights/stats.js
+++ b/components/widgets/pagespeed-insights/stats.js
@@ -69,35 +69,37 @@ export default class PageSpeedInsightsStats extends Component {
     return (
       <Widget title={title} loading={loading} error={error}>
         <Table>
-          <tr>
-            <Th>Request</Th>
-            <Td>{stats.requestSize} KB ({stats.requestCount})</Td>
-          </tr>
+          <tbody>
+            <tr>
+              <Th>Request</Th>
+              <Td>{stats.requestSize} KB ({stats.requestCount})</Td>
+            </tr>
 
-          <tr>
-            <Th>JavaScript</Th>
-            <Td>{stats.javascriptSize} KB ({stats.javascriptCount})</Td>
-          </tr>
+            <tr>
+              <Th>JavaScript</Th>
+              <Td>{stats.javascriptSize} KB ({stats.javascriptCount})</Td>
+            </tr>
 
-          <tr>
-            <Th>CSS</Th>
-            <Td>{stats.cssSize} KB ({stats.cssCount})</Td>
-          </tr>
+            <tr>
+              <Th>CSS</Th>
+              <Td>{stats.cssSize} KB ({stats.cssCount})</Td>
+            </tr>
 
-          <tr>
-            <Th>HTML</Th>
-            <Td>{stats.htmlSize} KB</Td>
-          </tr>
+            <tr>
+              <Th>HTML</Th>
+              <Td>{stats.htmlSize} KB</Td>
+            </tr>
 
-          <tr>
-            <Th>Image</Th>
-            <Td>{stats.imageSize} KB</Td>
-          </tr>
+            <tr>
+              <Th>Image</Th>
+              <Td>{stats.imageSize} KB</Td>
+            </tr>
 
-          <tr>
-            <Th>Other</Th>
-            <Td>{stats.otherSize} KB</Td>
-          </tr>
+            <tr>
+              <Th>Other</Th>
+              <Td>{stats.otherSize} KB</Td>
+            </tr>
+          </tbody>
         </Table>
       </Widget>
     )


### PR DESCRIPTION
* Add `tbody`
* Remove unused locale prop
* Set `filter_third_party_resources` default to `false`
* Remove CORS proxy from Jenkins widget example