### PR TITLE
Update hapi-rest-proxy example with a valid url

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ docker run -d -p 3001:8080 chrishelgert/hapi-rest-proxy
 
 ```javascript
 <SonarQube
-  url='http://localhost:3001?url=https://sonarcloud.io'
+  url='http://localhost:3001/?url=https://sonarcloud.io'
   componentKey='com.icegreen:greenmail-parent'
 />
 ```


### PR DESCRIPTION
Update the _hapi-rest-proxy_ example:

**Invalid URL:** http://localhost:3001?url=https://sonarcloud.io
**Valid URL:** http://localhost:3001/?url=https://sonarcloud.io