### PR TITLE
Update Jenkins example

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ import DateTime from '../components/widgets/datetime'
 import Jenkins from '../components/widgets/jenkins'
 
 <Jenkins
-  url='http://ci.jenkins-ci.org'
+  url='https://builds.apache.org'
   jobs={[
-    { label: 'jenkins master', path: 'Core/job/jenkins/job/master' },
-    { label: 'jenkins stable', path: 'Core/job/jenkins/job/stable-2.7'},
-    { label: 'jenkins sshd', path: 'Core/job/sshd-module/job/master' },
+    { label: 'Hadoop', path: 'Hadoop-trunk-Commit' },
+    { label: 'Jackrabbit', path: 'Jackrabbit-trunk' },
+    { label: 'JMeter', path: 'JMeter-trunk' }
   ]}
 />
 ```

--- a/pages/index.js
+++ b/pages/index.js
@@ -42,11 +42,11 @@ export default () => (
     />
 
     <Jenkins
-      url='https://crossorigin.me/http://ci.jenkins-ci.org'
+      url='https://crossorigin.me/https://builds.apache.org'
       jobs={[
-        { label: 'jenkins master', path: 'Core/job/jenkins/job/master' },
-        { label: 'jenkins stable', path: 'Core/job/jenkins/job/stable-2.7' },
-        { label: 'jenkins sshd', path: 'Core/job/sshd-module/job/master' }
+        { label: 'Hadoop', path: 'Hadoop-trunk-Commit' },
+        { label: 'Jackrabbit', path: 'Jackrabbit-trunk' },
+        { label: 'JMeter', path: 'JMeter-trunk' }
       ]}
     />
 


### PR DESCRIPTION
Replace `http://ci.jenkins-ci.org` with `https://builds.apache.org` because the api has been disabled.
See https://jenkins.io/infra/ci-redirects/.