### PR TITLE
Remove unnecessary stylelint rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,9 +73,6 @@
       "stylelint-config-standard",
       "stylelint-config-styled-components"
     ],
-    "syntax": "scss",
-    "rules": {
-      "value-list-max-empty-lines": null
-    }
+    "syntax": "scss"
   }
 }


### PR DESCRIPTION
With 4370a7b96e5a08d516ccc706644d77f091fb0faf the rule is obsolete.