### PR TITLE
Remove padding from Container to avoid useless scrollbar

### DIFF
--- a/components/dashboard.js
+++ b/components/dashboard.js
@@ -18,7 +18,6 @@ const Container = styled.main`
   flex-flow: row wrap;
   justify-content: center;
   min-height: 100vh;
-  padding: 1em;
 `
 
 export default ({ children, theme, title = 'Dashboard' }) => (


### PR DESCRIPTION
This bugfix prevents a vertical scrollbar which currently appears if the content is < 100% of the window height.