### PR TITLE
Fix Error in "Title" Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ import GitHubIssueCount from '../components/github/issue-count'
 #### Example
 
 ```javascript
-import Title from '../components/github/title'
+import Title from '../components/widgets/title'
 
 <Title>API Status</Title>
 ```


### PR DESCRIPTION
The example tried to import "Title" from "../components/github/title", while the right path is "../components/widgets/title".