### PR TITLE
Fix negative seconds for jenkins build duration

### DIFF
--- a/components/widgets/jenkins/build-duration.js
+++ b/components/widgets/jenkins/build-duration.js
@@ -55,7 +55,7 @@ export default class JenkinsBuildDuration extends Component {
     const s = ms / 1000
 
     if (s > 60) {
-      const min = Math.round(s / 60)
+      const min = Math.floor(s / 60)
       let minSec = Math.round(s - (min * 60))
       minSec = minSec.toString().length === 1 ? `0${minSec}` : minSec
 


### PR DESCRIPTION
If a build takes more than half of full minute, the seconds are displayed as negative value. For example, if a build takes 10:35 minutes, the dashboard shows "11:-25".
This commit fixes the problem.